### PR TITLE
保存下载文件的目录结构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.zip
 *.txt
 */
+**/test


### PR DESCRIPTION
用`pathlib`重写了一下路径操作，同时修改了`construct_attchment_list`以保存下载文件的目录结构。

多进程加速我感觉是不可行了，server端只要检测到并发的数据传输就会关闭链接，也不太想整header那套东西 : (