### PR TITLE
Feature: Add a "cid_include_list" option in config that enable users to download certain courses

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,7 +1,8 @@
 {
 	"username": "13500000000",
 	"password": "somepassword",
-    "ext_expel_list": ["mp4", "pdf"],
+	"ext_expel_list": ["mp4", "pdf"],
+	"cid_include_list": [],
 	"cid_expel_list": [12102],
 	"save_path" : "",
 	"keep_dirs": false

--- a/download.py
+++ b/download.py
@@ -63,8 +63,8 @@ with open('config.json', 'r') as f:
     user_name = config.get('username')
     user_passwd = config.get('password')
     ext_expel_list = config.get('ext_expel_list')
-    cid_include_list = list(map(str, config.get('cid_include_list')))
-    cid_expel_list = list(map(str, config.get('cid_expel_list')))
+    cid_include_list = list(map(str, config.get('cid_include_list', [])))
+    cid_expel_list = list(map(str, config.get('cid_expel_list', [])))
     save_path = config.get('save_path', "")
     keep_dirs = config.get('keep_dirs', False)
 
@@ -117,7 +117,7 @@ def check_cid(cid):
         return False
     return cid not in cid_expel_list
 
-print("Ready to download the following courses:")
+print("\nReady to download the following courses:")
 for cid, cname in cid2name_dict.items():
     if not check_cid(cid):
         continue

--- a/download.py
+++ b/download.py
@@ -63,6 +63,7 @@ with open('config.json', 'r') as f:
     user_name = config.get('username')
     user_passwd = config.get('password')
     ext_expel_list = config.get('ext_expel_list')
+    cid_include_list = list(map(str, config.get('cid_include_list')))
     cid_expel_list = list(map(str, config.get('cid_expel_list')))
     save_path = config.get('save_path', "")
     keep_dirs = config.get('keep_dirs', False)
@@ -111,10 +112,21 @@ for entry in info:
 
 cid_list = cid2name_dict.keys()
 
+def check_cid(cid):
+    if len(cid_include_list) and cid not in cid_include_list:
+        return False
+    return cid not in cid_expel_list
+
+print("Ready to download the following courses:")
+for cid, cname in cid2name_dict.items():
+    if not check_cid(cid):
+        continue
+    print(cname, cid)
+
 for cid in cid_list:
     cid = str(cid) # Prevent bug caused by wrong type of cid
 
-    if cid in cid_expel_list:
+    if not check_cid(cid):
         continue
 
     try:


### PR DESCRIPTION
- New "cid_include_list" key in config.json that contains a list of class IDs to download, will be skipped if kept empty
- Now prints all selected courses before downloading files from them
